### PR TITLE
PEM Imports and Exports + Code Refactoring

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,8 +29,8 @@ let package = Package(
             name: "PeerID",
             dependencies: [
                 .product(name: "LibP2PCrypto", package: "swift-libp2p-crypto"),
-                .product(name: "CID", package: "swift-cid"),
                 .product(name: "Multihash", package: "swift-multihash"),
+                .product(name: "CID", package: "swift-cid"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
             ],
             resources: [

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-crypto.git", .upToNextMajor(from: "0.0.1")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-crypto.git", .upToNextMinor(from: "0.1.1")),
         .package(url: "https://github.com/swift-libp2p/swift-multihash.git", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/swift-libp2p/swift-cid.git", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.12.0"))

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ peerID.keyPair?.keyType == .ed25519     // The type of Key
 peerID.keyPair?.privateKey              // Access to the private key (for signing)
 peerID.keyPair?.publicKey               // Access to the public key (for verifying signatures)
 
+/// If you want to reuse the same PeerID between sessions, you can... 
+        
+/// Export a PeerID as an Encrypted PEM String that you can store... 
+let encryptedPEM = try peerID.exportKeyPair(as: .privatePEMString(encryptedWithPassword: "mypassword"))
+
+/// And then load the PeerID from and encrypted PEM String later
+let peerID = try PeerID(pem: "ENCRYPTED_PEM_String", password: "mypassword")
 ```
 
 ### API
@@ -108,6 +115,8 @@ PeerID.init(marshaledPrivateKey str:String, base:BaseEncoding) throws
 /// Inits a `PeerID` from a marshaled private key
 PeerID.init(marshaledPrivateKey data:Data) throws
 
+/// Inits a `PeerID` from a PEM String
+PeerID.init(pem: String, withPassword: String? = nil) throws
 
 /// Properties
 /// Returns the PeerID's id as a base58 string (multihash/CIDv0).
@@ -136,6 +145,8 @@ PeerID.toJSON(includingPrivateKey:Bool = false) throws -> Data
 /// Exports our PeerID as a JSON string
 PeerID.toJSONString(includingPrivateKey:Bool = false) throws -> String?
 
+/// Exports our PeerID as a PEM String
+PeerID.exportKeyPair(as: PeerID.ExportType) throws -> String
 
 /// Signing and Verifying
 // Signs data using this PeerID's private key. This signature can then be verified by a remote peer using this PeerID's public key

--- a/Sources/PeerID/PeerID+Equatable.swift
+++ b/Sources/PeerID/PeerID+Equatable.swift
@@ -1,0 +1,20 @@
+//
+//  PeerID+Equatable.swift
+//  
+//
+//  Created by Brandon Toms on 9/23/22.
+//
+
+import Foundation
+
+extension PeerID:Equatable {
+    public static func == (lhs: PeerID, rhs: PeerID) -> Bool {
+        lhs.id == rhs.id
+    }
+    public static func == (lhs: [UInt8], rhs: PeerID) -> Bool {
+        lhs == rhs.id
+    }
+    public static func == (lhs: Data, rhs: PeerID) -> Bool {
+        lhs.bytes == rhs.id
+    }
+}

--- a/Sources/PeerID/PeerID+JSON.swift
+++ b/Sources/PeerID/PeerID+JSON.swift
@@ -1,0 +1,86 @@
+//
+//  PeerID+JSON.swift
+//  
+//
+//  Created by Brandon Toms on 9/23/22.
+//
+
+import LibP2PCrypto
+import Foundation
+import Multihash
+
+/// - MARK: JSON Imports and Exports
+public extension PeerID {
+    /// An Internal PeerID struct to facilitate JSON Encoding and Decoding
+    internal struct PeerIDJSON:Codable {
+        /// base58 encoded string
+        let id:String
+        /// base64 encoded publicKey protobuf
+        let pubKey:String?
+        /// base64 encoded privateKey protobuf
+        let privKey:String?
+    }
+    
+    /// Initialize a PeerID from JSON data
+    ///
+    /// Expects a JSON object of the form
+    /// ```
+    /// {
+    ///   obj.id: String - The multihash encoded in base58
+    ///   obj.pubKey: String? - The public key in protobuf format, encoded in 'base64'
+    ///   obj.privKey: String? - The private key in protobuf format, encoded in 'base64'
+    /// }
+    /// ```
+    convenience init(fromJSON json:Data) throws {
+        let data = try JSONDecoder().decode(PeerIDJSON.self, from: json)
+        
+        if data.privKey == nil && data.pubKey == nil {
+            /// Only ID Present...
+            try self.init(fromBytesID: Multihash(b58String: data.id).value)
+        } else if data.privKey == nil, let pubKey = data.pubKey {
+            /// Only Public Key and ID Present, lets init via the public key and derive the ID
+            /// TODO: Compare the provided ID and the Derived ID and throw an error if they dont match...
+            try self.init(marshaledPublicKey: pubKey, base: .base64)
+        } else if let privKey = data.privKey {
+            /// Private Key was provided. Lets init via the private key and derive both the public key and the ID
+            /// TODO: Compare the provided publicKey and ID to the ones derived from the private key and throw an error if they don't match...
+            try self.init(marshaledPrivateKey: privKey, base: .base64)
+        } else {
+            throw NSError(domain: "Failed to init PeerID from json", code: 0, userInfo: nil)
+        }
+    }
+    
+    /// Exports our PeerID as a JSON object
+    ///
+    /// Returns a JSON object of the form
+    /// ```
+    /// {
+    ///   id: String - The multihash encoded in base58
+    ///   pubKey: String? - The public key in protobuf format, encoded in 'base64'
+    ///   privKey: String? - The private key in protobuf format, encoded in 'base64'
+    /// }
+    /// ```
+    func toJSON(includingPrivateKey:Bool = false) throws -> Data {
+        let pidJSON = PeerIDJSON(
+            id: self.b58String,
+            pubKey: try? self.keyPair?.publicKey.marshal().asString(base: .base64),
+            privKey: includingPrivateKey ? try? self.keyPair?.privateKey?.marshal().asString(base: .base64) : nil
+        )
+        
+        return try JSONEncoder().encode(pidJSON)
+    }
+    
+    /// Exports our PeerID as a JSON object
+    ///
+    /// Returns a JSON object as a String
+    /// ```
+    /// {
+    ///   id: String - The multihash encoded in base58
+    ///   pubKey: String? - The public key in protobuf format, encoded in 'base64'
+    ///   privKey: String? - The private key in protobuf format, encoded in 'base64'
+    /// }
+    /// ```
+    func toJSONString(includingPrivateKey:Bool = false) throws -> String? {
+        return try String(data: self.toJSON(), encoding: .utf8)
+    }
+}

--- a/Sources/PeerID/PeerID+Marshaled.swift
+++ b/Sources/PeerID/PeerID+Marshaled.swift
@@ -1,0 +1,118 @@
+//
+//  PeerID+Marshaled.swift
+//  
+//
+//  Created by Brandon Toms on 9/23/22.
+//
+
+import LibP2PCrypto
+import Foundation
+import Multibase
+
+/// - MARK: Marshaled Imports and Exports
+public extension PeerID {
+    /// Inits a `PeerID` from a marshaled `PeerID` string
+    /// - Note: `base` can be left `nil` if the marshaledPeerID String is `Multibase` compliant (includes the multibase prefix) otherwise, you must specify the ecoded base of the string...
+    convenience init(marshaledPeerID:String, base: BaseEncoding? = nil) throws {
+        let marshaledData:Data
+        if let base = base {
+            marshaledData = try BaseEncoding.decode(marshaledPeerID, as: base).data
+        } else {
+            marshaledData = try BaseEncoding.decode(marshaledPeerID).data
+        }
+        try self.init(marshaledPeerID: marshaledData)
+    }
+    
+    /// Inits a `PeerID` from a marshaled `PeerID`
+    convenience init(marshaledPeerID data:Data) throws {
+        // Attampt to instantiate a PeerIdProto with the raw, marshaled, data
+        let protoPeerID = try PeerIdProto(contiguousBytes: data)
+        
+        //print(protoPeerID.id.asString(base: .base64))
+        //print("Has PubKey: \(protoPeerID.hasPubKey)")
+        //print(protoPeerID.pubKey.asString(base: .base64))
+        //print("Has PrivKey: \(protoPeerID.hasPrivKey)")
+        //print(protoPeerID.privKey.asString(base: .base64))
+        
+        // Enusre the Marshaled data included at least a public key (is this necessary, would we ever need to unmarshal an ID only?)
+        guard protoPeerID.hasPubKey || protoPeerID.hasPrivKey else {
+            throw NSError(domain: "No Public or Private Key Found in marshaled data", code: 0, userInfo: nil)
+        }
+        
+        // If we have a private key, attempt to instantiate the PeerID via the private key, otherwise, try the public key...
+        if protoPeerID.hasPrivKey {
+            try self.init(marshaledPrivateKey: protoPeerID.privKey)
+        } else if protoPeerID.hasPubKey {
+            try self.init(marshaledPublicKey: protoPeerID.pubKey)
+        } else {
+            throw NSError(domain: "No Public or Private Key Found in marshaled data", code: 0, userInfo: nil)
+        }
+    }
+    
+    /// Inits a `PeerID` from a marshaled public key string
+    convenience init(marshaledPublicKey str:String, base:BaseEncoding) throws {
+        try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(marshaledPublicKey: str, base: base))
+    }
+    
+    /// Inits a `PeerID` from a marshaled public key
+    convenience init(marshaledPublicKey key:Data) throws {
+        try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(marshaledPublicKey: key))
+    }
+    
+    /// Inits a `PeerID` from a marshaled private key string
+    convenience init(marshaledPrivateKey str:String, base:BaseEncoding) throws {
+        try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(marshaledPrivateKey: str, base: base))
+    }
+    
+    /// Inits a `PeerID` from a marshaled private key
+    convenience init(marshaledPrivateKey data:Data) throws {
+        try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(marshaledPrivateKey: data))
+    }
+    
+    
+//    private static func computeDigest(pubKey:SecKey) throws -> [UInt8] {
+//        let bytes = try pubKey.rawRepresentation()
+//        return try self.computeDigest(rawPubKey: bytes)
+//    }
+//
+//    /// - Note: We need to marshal the raw public key before multihashing it....
+//    private static func computeDigest(rawPubKey bytes:Data) throws -> [UInt8] {
+//        let marshaled = try LibP2PCrypto.Keys.marshalPublicKey(raw: bytes, keyType: .RSA(bits: .B1024))
+//        //print(marshaled.asString(base: .base64Pad))
+//        if marshaled.count <= 42 {
+//            return try Multihash(raw: marshaled, hashedWith: .identity).value
+//        } else {
+//            //let mh = try Multihash(raw: bytes, hashedWith: .sha2_256)
+//            //print("Value: \(mh.value.asString(base: .base16))")
+//            //print("Hex: \(mh.hexString)")
+//            //print("Digest: \(mh.digest?.asString(base: .base16) ?? "NIL")")
+//            return try Multihash(raw: marshaled, hashedWith: .sha2_256).value //pubKey.hash()
+//        }
+//    }
+    
+
+    /// Returns a protocol-buffers encoded version of the id, public key and, if `includingPrivateKey` is set to `true`, the private key.
+    func marshal(includingPrivateKey:Bool = false) throws -> [UInt8] {
+        var pid = PeerIdProto()
+        pid.id = Data(self.id)
+        pid.pubKey = try self.keyPair?.publicKey.marshal() ?? Data()
+        if includingPrivateKey, let privKey = self.keyPair?.privateKey {
+            pid.privKey = try privKey.marshal()
+        }
+        return try pid.serializedData().bytes
+    }
+    
+    func marshalPrivateKey() throws -> [UInt8] {
+        guard let privKey = self.keyPair?.privateKey else {
+            throw NSError(domain: "This PeerID doesn't have a Private Key to Marshal", code: 0, userInfo: nil)
+        }
+        return try privKey.marshal().bytes
+    }
+
+    func marshalPublicKey() throws -> [UInt8] {
+        guard let pubKey = self.keyPair?.publicKey else {
+            throw NSError(domain: "This PeerID doesn't have a Public Key to Marshal", code: 0, userInfo: nil)
+        }
+        return try pubKey.marshal().bytes
+    }
+}

--- a/Sources/PeerID/PeerID+PEM.swift
+++ b/Sources/PeerID/PeerID+PEM.swift
@@ -1,0 +1,37 @@
+//
+//  PeerID+PEM.swift
+//  
+//
+//  Created by Brandon Toms on 9/23/22.
+//
+
+import LibP2PCrypto
+import Foundation
+
+/// - MARK: PEM Imports and Exports
+public extension PeerID {
+    convenience init(pem: String, password: String?) throws {
+      try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(pem: pem, password: password))
+    }
+
+    enum ExportType {
+        case publicPEMString
+        case privatePEMString(encryptedWithPassword:String)
+        case unencrypredPrivatePEMString
+    }
+
+    /// Exports the KeyPair as  PEM structured String. Private Keys can be encrypted with a password before export.
+    func exportKeyPair(as exportType:ExportType) throws -> String {
+        guard let keyPair = self.keyPair else { throw NSError(domain: "No Underlying Key Pair to Export", code: 0, userInfo: nil) }
+        switch exportType {
+        case .publicPEMString:
+            return try keyPair.publicKey.exportPublicKeyPEMString(withHeaderAndFooter: true)
+        case .unencrypredPrivatePEMString:
+            guard keyPair.privateKey != nil else { throw NSError(domain: "No Private Key to Export", code: 0, userInfo: nil) }
+            return try keyPair.exportPrivatePEMString(withHeaderAndFooter: true)
+        case .privatePEMString(let password):
+            guard !password.isEmpty else { throw NSError(domain: "Password shouldn't be empty", code: 0, userInfo: nil) }
+            return try keyPair.exportEncryptedPrivatePEMString(withPassword: password)
+        }
+    }
+}

--- a/Sources/PeerID/PeerID+Signatures.swift
+++ b/Sources/PeerID/PeerID+Signatures.swift
@@ -1,0 +1,30 @@
+//
+//  PeerID+Signature.swift
+//  
+//
+//  Created by Brandon Toms on 9/23/22.
+//
+
+import LibP2PCrypto
+import Foundation
+
+/// - MARK: PeerID Signatures and Verification Methods
+public extension PeerID {
+    // Signs data using this PeerID's private key. This signature can then be verified by a remote peer using this PeerID's public key
+    func signature(for msg:Data) throws -> Data {
+        guard let priv = keyPair?.privateKey else {
+            throw NSError(domain: "A private key is required for generating signature and this PeerID doesn't contain a private key.", code: 0, userInfo: nil)
+        }
+        
+        return try priv.sign(message: msg)
+    }
+    
+    // Using this PeerID's public key, this method checks to see if the signature data was in fact signed by this peer and is a valid signature for the expected data
+    func isValidSignature(_ signature:Data, for expectedData:Data) throws -> Bool {
+        guard let pub = keyPair?.publicKey else {
+            throw NSError(domain: "A public key is required for verifying signatures and this PeerID doesn't contain a public key.", code: 0, userInfo: nil)
+        }
+        
+        return try pub.verify(signature: signature, for: expectedData)
+    }
+}

--- a/Sources/PeerID/PeerID.swift
+++ b/Sources/PeerID/PeerID.swift
@@ -1,9 +1,14 @@
+//
+//  PeerID.swift
+//
+//
+//  Created by Brandon Toms on 5/1/22.
+//
 
+import LibP2PCrypto
 import Foundation
 import Multihash
-import Multibase
 import CID
-import LibP2PCrypto
 
 /// - Reference: https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#how-keys-are-encoded-and-messages-signed
 public class PeerID {
@@ -103,178 +108,6 @@ public class PeerID {
         self.keyPair = nil
     }
     
-    /// Inits a `PeerID` from a marshaled `PeerID` string
-    /// - Note: `base` can be left `nil` if the marshaledPeerID String is `Multibase` compliant (includes the multibase prefix) otherwise, you must specify the ecoded base of the string...
-    public convenience init(marshaledPeerID:String, base: BaseEncoding? = nil) throws {
-        let marshaledData:Data
-        if let base = base {
-            marshaledData = try BaseEncoding.decode(marshaledPeerID, as: base).data
-        } else {
-            marshaledData = try BaseEncoding.decode(marshaledPeerID).data
-        }
-        try self.init(marshaledPeerID: marshaledData)
-    }
-    
-    /// Inits a `PeerID` from a marshaled `PeerID`
-    public convenience init(marshaledPeerID data:Data) throws {
-        // Attampt to instantiate a PeerIdProto with the raw, marshaled, data
-        let protoPeerID = try PeerIdProto(contiguousBytes: data)
-        
-        //print(protoPeerID.id.asString(base: .base64))
-        //print("Has PubKey: \(protoPeerID.hasPubKey)")
-        //print(protoPeerID.pubKey.asString(base: .base64))
-        //print("Has PrivKey: \(protoPeerID.hasPrivKey)")
-        //print(protoPeerID.privKey.asString(base: .base64))
-        
-        // Enusre the Marshaled data included at least a public key (is this necessary, would we ever need to unmarshal an ID only?)
-        guard protoPeerID.hasPubKey || protoPeerID.hasPrivKey else {
-            throw NSError(domain: "No Public or Private Key Found in marshaled data", code: 0, userInfo: nil)
-        }
-        
-        // If we have a private key, attempt to instantiate the PeerID via the private key, otherwise, try the public key...
-        if protoPeerID.hasPrivKey {
-            try self.init(marshaledPrivateKey: protoPeerID.privKey)
-        } else if protoPeerID.hasPubKey {
-            try self.init(marshaledPublicKey: protoPeerID.pubKey)
-        } else {
-            throw NSError(domain: "No Public or Private Key Found in marshaled data", code: 0, userInfo: nil)
-        }
-    }
-    
-    /// Inits a `PeerID` from a marshaled public key string
-    public convenience init(marshaledPublicKey str:String, base:BaseEncoding) throws {
-        try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(marshaledPublicKey: str, base: base))
-    }
-    
-    /// Inits a `PeerID` from a marshaled public key
-    public convenience init(marshaledPublicKey key:Data) throws {
-        try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(marshaledPublicKey: key))
-    }
-    
-    /// Inits a `PeerID` from a marshaled private key string
-    public convenience init(marshaledPrivateKey str:String, base:BaseEncoding) throws {
-        try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(marshaledPrivateKey: str, base: base))
-    }
-    
-    /// Inits a `PeerID` from a marshaled private key
-    public convenience init(marshaledPrivateKey data:Data) throws {
-        try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(marshaledPrivateKey: data))
-    }
-    
-    /// An Internal PeerID struct to facilitate JSON Encoding and Decoding
-    internal struct PeerIDJSON:Codable {
-        /// base58 encoded string
-        let id:String
-        /// base64 encoded publicKey protobuf
-        let pubKey:String?
-        /// base64 encoded privateKey protobuf
-        let privKey:String?
-    }
-    
-    /// Initialize a PeerID from JSON data
-    ///
-    /// Expects a JSON object of the form
-    /// ```
-    /// {
-    ///   obj.id: String - The multihash encoded in base58
-    ///   obj.pubKey: String? - The public key in protobuf format, encoded in 'base64'
-    ///   obj.privKey: String? - The private key in protobuf format, encoded in 'base64'
-    /// }
-    /// ```
-    public convenience init(fromJSON json:Data) throws {
-        let data = try JSONDecoder().decode(PeerIDJSON.self, from: json)
-        
-        if data.privKey == nil && data.pubKey == nil {
-            /// Only ID Present...
-            try self.init(fromBytesID: Multihash(b58String: data.id).value)
-        } else if data.privKey == nil, let pubKey = data.pubKey {
-            /// Only Public Key and ID Present, lets init via the public key and derive the ID
-            /// TODO: Compare the provided ID and the Derived ID and throw an error if they dont match...
-            try self.init(marshaledPublicKey: pubKey, base: .base64)
-        } else if let privKey = data.privKey {
-            /// Private Key was provided. Lets init via the private key and derive both the public key and the ID
-            /// TODO: Compare the provided publicKey and ID to the ones derived from the private key and throw an error if they don't match...
-            try self.init(marshaledPrivateKey: privKey, base: .base64)
-        } else {
-            throw NSError(domain: "Failed to init PeerID from json", code: 0, userInfo: nil)
-        }
-    }
-    
-    /// Exports our PeerID as a JSON object
-    ///
-    /// Returns a JSON object of the form
-    /// ```
-    /// {
-    ///   obj.id: String - The multihash encoded in base58
-    ///   obj.pubKey: String? - The public key in protobuf format, encoded in 'base64'
-    ///   obj.privKey: String? - The private key in protobuf format, encoded in 'base64'
-    /// }
-    /// ```
-    public func toJSON(includingPrivateKey:Bool = false) throws -> Data {
-        let pidJSON = PeerIDJSON(
-            id: self.b58String,
-            pubKey: try? self.keyPair?.publicKey.marshal().asString(base: .base64),
-            privKey: includingPrivateKey ? try? self.keyPair?.privateKey?.marshal().asString(base: .base64) : nil
-        )
-        
-        return try JSONEncoder().encode(pidJSON)
-    }
-    
-    public func toJSONString(includingPrivateKey:Bool = false) throws -> String? {
-        return try String(data: self.toJSON(), encoding: .utf8)
-    }
-    
-    
-//    private static func computeDigest(pubKey:SecKey) throws -> [UInt8] {
-//        let bytes = try pubKey.rawRepresentation()
-//        return try self.computeDigest(rawPubKey: bytes)
-//    }
-//
-//    /// - Note: We need to marshal the raw public key before multihashing it....
-//    private static func computeDigest(rawPubKey bytes:Data) throws -> [UInt8] {
-//        let marshaled = try LibP2PCrypto.Keys.marshalPublicKey(raw: bytes, keyType: .RSA(bits: .B1024))
-//        //print(marshaled.asString(base: .base64Pad))
-//        if marshaled.count <= 42 {
-//            return try Multihash(raw: marshaled, hashedWith: .identity).value
-//        } else {
-//            //let mh = try Multihash(raw: bytes, hashedWith: .sha2_256)
-//            //print("Value: \(mh.value.asString(base: .base16))")
-//            //print("Hex: \(mh.hexString)")
-//            //print("Digest: \(mh.digest?.asString(base: .base16) ?? "NIL")")
-//            return try Multihash(raw: marshaled, hashedWith: .sha2_256).value //pubKey.hash()
-//        }
-//    }
-    
-
-    /// Returns a protocol-buffers encoded version of the id, public key and, if `includingPrivateKey` is set to `true`, the private key.
-    public func marshal(includingPrivateKey:Bool = false) throws -> [UInt8] {
-        var pid = PeerIdProto()
-        pid.id = Data(self.id)
-        pid.pubKey = try self.keyPair?.publicKey.marshal() ?? Data()
-        if includingPrivateKey, let privKey = self.keyPair?.privateKey {
-            pid.privKey = try privKey.marshal()
-        }
-        return try pid.serializedData().bytes
-    }
-    
-    public func marshalPrivateKey() throws -> [UInt8] {
-        guard let privKey = self.keyPair?.privateKey else {
-            throw NSError(domain: "This PeerID doesn't have a Private Key to Marshal", code: 0, userInfo: nil)
-        }
-        return try privKey.marshal().bytes
-    }
-
-    public func marshalPublicKey() throws -> [UInt8] {
-        guard let pubKey = self.keyPair?.publicKey else {
-            throw NSError(domain: "This PeerID doesn't have a Public Key to Marshal", code: 0, userInfo: nil)
-        }
-        return try pubKey.marshal().bytes
-    }
-    
-//    public func marshalPublicKeyAsProtobuf() throws -> LibP2PCrypto.PublicKey {
-//        
-//    }
-    
     /// Returns the PeerID's id as a self-describing CIDv1 in Base32 (RFC 0001)
     /// return self-describing String representation
     /// in default format from RFC 0001: https://github.com/libp2p/specs/pull/209
@@ -292,31 +125,11 @@ public class PeerID {
     private func toBase64Pad(_ buf:[UInt8]) -> String {
         buf.asString(base: .base64Pad)
     }
-    
-    // Signs data using this PeerID's private key. This signature can then be verified by a remote peer using this PeerID's public key
-    public func signature(for msg:Data) throws -> Data {
-        guard let priv = keyPair?.privateKey else {
-            throw NSError(domain: "A private key is required for generating signature and this PeerID doesn't contain a private key.", code: 0, userInfo: nil)
-        }
-        
-        return try priv.sign(message: msg)
-    }
-    
-    // Using this PeerID's public key, this method checks to see if the signature data was in fact signed by this peer and is a valid signature for the expected data
-    public func isValidSignature(_ signature:Data, for expectedData:Data) throws -> Bool {
-        guard let pub = keyPair?.publicKey else {
-            throw NSError(domain: "A public key is required for verifying signatures and this PeerID doesn't contain a public key.", code: 0, userInfo: nil)
-        }
-        
-        return try pub.verify(signature: signature, for: expectedData)
-    }
 }
 
 extension PeerID:CustomStringConvertible {
     public var description: String {
         let pid = self.b58String
-        // All sha256 nodes start with Qm
-        // We can skip the Qm to make the peer.ID more useful
         var skip = 0
         if pid.hasPrefix("Qm") {
             skip = 2
@@ -328,8 +141,6 @@ extension PeerID:CustomStringConvertible {
     
     public var shortDescription: String {
         let pid = self.b58String
-        // All sha256 nodes start with Qm
-        // We can skip the Qm to make the peer.ID more useful
         if pid.hasPrefix("Qm") {
             return String(pid.dropFirst(2).prefix(6))
         } else if pid.hasPrefix("12D3KooW") {
@@ -355,17 +166,6 @@ private extension Array where Element == UInt8 {
     }
 }
 
-extension PeerID:Equatable {
-    public static func == (lhs: PeerID, rhs: PeerID) -> Bool {
-        lhs.id == rhs.id
-    }
-    public static func == (lhs: [UInt8], rhs: PeerID) -> Bool {
-        lhs == rhs.id
-    }
-    public static func == (lhs: Data, rhs: PeerID) -> Bool {
-        lhs.bytes == rhs.id
-    }
-}
 //public func computeDigest(rawPubKey:Data) -> Data {
 //    if rawPubKey.count <= 42 {
 //        return Multihash(raw: rawPubKey, hashedWith: .identity)


### PR DESCRIPTION
This PR includes...

- Support for swift-libp2p-crypto v0.1 API
- Exposes PEM import and export methods on PeerID
- Adds a couple new PEM focused tests
- Supports Marshaling Private RSA Keys on Linux now
-  Refactored / organized code