### PR TITLE
Embedded Public Key IDs

### DIFF
--- a/Sources/PeerID/PeerID+Equatable.swift
+++ b/Sources/PeerID/PeerID+Equatable.swift
@@ -16,7 +16,7 @@ import Foundation
 
 extension PeerID: Equatable {
     public static func == (lhs: PeerID, rhs: PeerID) -> Bool {
-        lhs.id == rhs.id
+        lhs.id == rhs.id || lhs.isEquivalent(to: rhs)
     }
     public static func == (lhs: [UInt8], rhs: PeerID) -> Bool {
         lhs == rhs.id

--- a/Sources/PeerID/PeerID.swift
+++ b/Sources/PeerID/PeerID.swift
@@ -205,24 +205,12 @@ public class PeerID {
 extension PeerID: CustomStringConvertible {
     public var description: String {
         let pid = self.b58String
-        var skip = 0
-        if pid.hasPrefix("Qm") {
-            skip = 2
-        } else if pid.hasPrefix("12D3KooW") {
-            skip = 8
-        }
-        return "<peer.ID \(pid.dropFirst(skip).prefix(6))>"
+        return "<peer.ID \(dropPrefix(pid).prefix(6))>"
     }
 
     public var shortDescription: String {
         let pid = self.b58String
-        if pid.hasPrefix("Qm") {
-            return String(pid.dropFirst(2).prefix(6))
-        } else if pid.hasPrefix("12D3KooW") {
-            return String(pid.dropFirst(8).prefix(6))
-        } else {
-            return String(pid.prefix(6))
-        }
+        return String(dropPrefix(pid).prefix(6))
     }
 
     public var debugDescription: String {
@@ -232,6 +220,16 @@ extension PeerID: CustomStringConvertible {
             pubKey: \(keyPair?.publicKey.asString(base: .base64Pad) ?? "NIL")
             privKey: \(keyPair?.privateKey?.asString(base: .base64Pad) ?? "NIL")
         """
+    }
+
+    private func dropPrefix(_ pid: String) -> String.SubSequence {
+        var skip = 0
+        if pid.hasPrefix("Qm") {
+            skip = 2
+        } else if pid.hasPrefix("12D3KooW") {
+            skip = 8
+        }
+        return pid.dropFirst(skip)
     }
 }
 


### PR DESCRIPTION
### What:
- This PR adds additional support for PeerIDs with embedded public keys in their ID.

### Changes:
- The `PeerID` equality check can now compare across traditional (SHA256) and Embedded PubKey (Identity) IDs.
- Introduced `public func traditionalB58String() throws -> String` to force the traditional SHA256 version of the ID.
- The existing `CID` initializers support embedded public key ID's now.
- `PeerID` stores the actual `Multihash` instead of just the `Multihash`'s underlying value.

### Fixes:
#11 

### Result:
Allows the following
``` swift
// Embedded Public Key
let peerID1 = try PeerID(cid: "12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d")
// Traditional (SHA256 variant)
let peerID2 = try PeerID(cid: "QmPoHmYtUt8BU9eiwMYdBfT6rooBnna5fdAZHUaZASGQY8")

// Equality Check
print(peerID1 == peerID2)  // true

// Embedded version has a public key available (for signature verification, etc)
print(peerID1.type)  // .isPublic

// Traditional version does not have a public key (it's an ID only)
print(peerID2.type)  // .idOnly

// Embedded PeerID's
// default to staying embedded
print(peerID1.b58String)  // 12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d

// but we can still grab the traditional SHA256 value if necessary
print(peerID1.traditionalB58String())  // QmPoHmYtUt8BU9eiwMYdBfT6rooBnna5fdAZHUaZASGQY8

// Traditional PeerIDs
// can only ever be traditional (since hashes are one way streets)
print(peerID2.b58String)  // QmPoHmYtUt8BU9eiwMYdBfT6rooBnna5fdAZHUaZASGQY8

print(peerID2.traditionalB58String())  // QmPoHmYtUt8BU9eiwMYdBfT6rooBnna5fdAZHUaZASGQY8

```