### PR TITLE
Replaced NSErrors with Typed Errors

### DIFF
--- a/Sources/PeerID/PeerID+JSON.swift
+++ b/Sources/PeerID/PeerID+JSON.swift
@@ -18,6 +18,12 @@ import Multihash
 
 /// - MARK: JSON Imports and Exports
 extension PeerID {
+    /// PeerID JSON Related Errors
+    public enum JSONError: Error {
+        /// Invalid JSON Payload
+        case invalidJSON
+    }
+
     /// An Internal PeerID struct to facilitate JSON Encoding and Decoding
     internal struct PeerIDJSON: Codable {
         /// base58 encoded string
@@ -53,7 +59,7 @@ extension PeerID {
             /// TODO: Compare the provided publicKey and ID to the ones derived from the private key and throw an error if they don't match...
             try self.init(marshaledPrivateKey: privKey, base: .base64)
         } else {
-            throw NSError(domain: "Failed to init PeerID from json", code: 0, userInfo: nil)
+            throw JSONError.invalidJSON
         }
     }
 

--- a/Sources/PeerID/PeerID+PEM.swift
+++ b/Sources/PeerID/PeerID+PEM.swift
@@ -17,32 +17,55 @@ import LibP2PCrypto
 
 /// - MARK: PEM Imports and Exports
 extension PeerID {
+
+    /// PeerID PEM Related Errors
+    public enum PEMError: Error {
+        /// No Underlying Key Pair to Export
+        case noKeypairToExport
+        /// This PeerID doesn't have a Private Key to Export
+        case noPrivateKeyAvailable
+        /// Password shouldn't be empty
+        case invalidPassword
+    }
+
+    /// Initializes a PeerID using a PEM string
+    /// - Parameters:
+    ///   - pem: The PEM file in string form
+    ///   - password: An optional password used to decrypt the PEM if it's encrypted
     public convenience init(pem: String, password: String?) throws {
         try self.init(keyPair: LibP2PCrypto.Keys.KeyPair(pem: pem, password: password))
     }
 
+    /// PEM Export Type
     public enum ExportType {
+        /// Exports the PeerID's backing Public Key as a PEM string
         case publicPEMString
+        /// Exports the PeerID's backing PrivateKey as a PEM string, encrypted with the password provided
         case privatePEMString(encryptedWithPassword: String)
+        /// Exports the PeerID's backing PrivateKey as an UNENCRYPTED PEM string
+        /// - WARNING: Not Recommended
+        /// - NOTE: Use the `.privatePEMString(encryptedWithPassword:)` method instead
         case unencrypredPrivatePEMString
     }
 
     /// Exports the KeyPair as  PEM structured String. Private Keys can be encrypted with a password before export.
+    /// - Parameter exportType: The type of PEM string to export
+    /// - Returns: The PEM string
     public func exportKeyPair(as exportType: ExportType) throws -> String {
         guard let keyPair = self.keyPair else {
-            throw NSError(domain: "No Underlying Key Pair to Export", code: 0, userInfo: nil)
+            throw PEMError.noKeypairToExport
         }
         switch exportType {
         case .publicPEMString:
             return try keyPair.publicKey.exportPublicKeyPEMString(withHeaderAndFooter: true)
         case .unencrypredPrivatePEMString:
             guard keyPair.privateKey != nil else {
-                throw NSError(domain: "No Private Key to Export", code: 0, userInfo: nil)
+                throw PEMError.noPrivateKeyAvailable
             }
             return try keyPair.exportPrivatePEMString(withHeaderAndFooter: true)
         case .privatePEMString(let password):
             guard !password.isEmpty else {
-                throw NSError(domain: "Password shouldn't be empty", code: 0, userInfo: nil)
+                throw PEMError.invalidPassword
             }
             return try keyPair.exportEncryptedPrivatePEMString(withPassword: password)
         }

--- a/Sources/PeerID/PeerID+Signatures.swift
+++ b/Sources/PeerID/PeerID+Signatures.swift
@@ -17,29 +17,34 @@ import LibP2PCrypto
 
 /// - MARK: PeerID Signatures and Verification Methods
 extension PeerID {
-    // Signs data using this PeerID's private key. This signature can then be verified by a remote peer using this PeerID's public key
+
+    /// PeerID PEM Related Errors
+    public enum SignatureError: Error {
+        /// A public key is required for verifying signatures and this PeerID doesn't contain a public key.
+        case noPublicKeyAvailable
+        /// A private key is required for generating signatures and this PeerID doesn't contain a private key.
+        case noPrivateKeyAvailable
+    }
+
+    /// Signs data using this PeerID's private key. This signature can then be verified by a remote peer using this PeerID's public key
+    /// - Parameter msg: The message to sign
+    /// - Returns: The signed message
     public func signature(for msg: Data) throws -> Data {
         guard let priv = keyPair?.privateKey else {
-            throw NSError(
-                domain:
-                    "A private key is required for generating signature and this PeerID doesn't contain a private key.",
-                code: 0,
-                userInfo: nil
-            )
+            throw SignatureError.noPrivateKeyAvailable
         }
 
         return try priv.sign(message: msg)
     }
 
-    // Using this PeerID's public key, this method checks to see if the signature data was in fact signed by this peer and is a valid signature for the expected data
+    /// Using this PeerID's public key, this method checks to see if the signature data was in fact signed by this peer and is a valid signature for the expected data
+    /// - Parameters:
+    ///   - signature: The signed message you want to validate
+    ///   - expectedData: The data you're comparing the signature against
+    /// - Returns: True if the expected data was signed by this PeerID's public key, or False if not.
     public func isValidSignature(_ signature: Data, for expectedData: Data) throws -> Bool {
         guard let pub = keyPair?.publicKey else {
-            throw NSError(
-                domain:
-                    "A public key is required for verifying signatures and this PeerID doesn't contain a public key.",
-                code: 0,
-                userInfo: nil
-            )
+            throw SignatureError.noPublicKeyAvailable
         }
 
         return try pub.verify(signature: signature, for: expectedData)


### PR DESCRIPTION
### What:
- Replaces NSErrors with Typed equivalent ones

### Changes:
Introduced the following enums conforming to the `Error` protocol
- `PeerID.Errors`
- `PeerID.JSONError`
- `PeerID.MarshallingError`
- `PeerID.PEMError`
- `PeerID.SignatureError`

### Fixes:
- #10 
